### PR TITLE
strokeColor is cached when changing drawingColor, affecting first points

### DIFF
--- a/Example/jot/ExampleViewController.m
+++ b/Example/jot/ExampleViewController.m
@@ -159,7 +159,6 @@ NSString * const kSaveImageName = @"";
     } else if (self.jotViewController.state == JotViewStateText) {
         self.jotViewController.state = JotViewStateDrawing;
         self.jotViewController.drawingColor = [UIColor colorWithRed:((double)arc4random()/UINT32_MAX) green:((double)arc4random()/UINT32_MAX) blue:((double)arc4random()/UINT32_MAX) alpha:1.0];
-        self.jotViewController.drawingStrokeWidth = self.jotViewController.drawingStrokeWidth;
         [self.toggleDrawingButton setTitle:kTextImageName forState:UIControlStateNormal];
     }
 }

--- a/Example/jot/ExampleViewController.m
+++ b/Example/jot/ExampleViewController.m
@@ -158,6 +158,8 @@ NSString * const kSaveImageName = @"";
         
     } else if (self.jotViewController.state == JotViewStateText) {
         self.jotViewController.state = JotViewStateDrawing;
+        self.jotViewController.drawingColor = [UIColor colorWithRed:((double)arc4random()/UINT32_MAX) green:((double)arc4random()/UINT32_MAX) blue:((double)arc4random()/UINT32_MAX) alpha:1.0];
+        self.jotViewController.drawingStrokeWidth = self.jotViewController.drawingStrokeWidth;
         [self.toggleDrawingButton setTitle:kTextImageName forState:UIControlStateNormal];
     }
 }

--- a/jot/JotDrawView.m
+++ b/jot/JotDrawView.m
@@ -192,6 +192,12 @@ CGFloat const kJotRelativeMinStrokeWidth = 0.4f;
     return self.strokeWidth - ((self.strokeWidth * (1.f - kJotRelativeMinStrokeWidth)) / (1.f + (CGFloat)pow((double)M_E, (double)(-((velocity - self.initialVelocity) / self.initialVelocity)))));
 }
 
+- (void)setStrokeColor:(UIColor *)strokeColor
+{
+    _strokeColor = strokeColor;
+    self.bezierPath = nil;
+}
+
 - (JotTouchBezier *)bezierPath
 {
     if (!_bezierPath) {


### PR DESCRIPTION
Now when strokeColor cool is changed bezier path with cached color is thrown out.
When toggling draw/text mode in example draw will be a random color

Example
![ios simulator screen shot jun 21 2015 1 37 01 pm](https://cloud.githubusercontent.com/assets/757940/8273619/b5521e60-182a-11e5-9046-ff3f181ff865.png)
